### PR TITLE
[ADD TOKEN] - WLAND

### DIFF
--- a/Tokens/WLAND.md
+++ b/Tokens/WLAND.md
@@ -1,0 +1,34 @@
+# WLAND
+
+- Token Name: WLAND
+- Ticker: WLAND
+- Data Create: 07-06-2026 00:00 UTC
+- Description: WLAND Token on Radiant Blockchain. Pre-minted Fungible Token (Glyph FT v2) for the WLAND VPN ecosystem.
+
+## Token info
+- Website: 
+- X: 
+- Discord: 
+
+## Tokenomics
+- Max Supply: 1,000,000,000
+- Premine: 1,000,000,000
+- Reward per mint: N/A (Pre-minted FT)
+- Contracts: N/A (Pre-minted FT)
+- Difficulty: N/A (Pre-minted FT)
+
+## Radiant ID
+```
+0dbd046d8c5ab8b7631cd896c271c65bf26cc578aa958a620543a4f0a6d7294b00000000
+```
+
+## Mint
+```
+N/A (Pre-minted FT - total supply issued at reveal TX)
+```
+
+## Contracts
+
+```
+N/A (Pre-minted FT)
+```


### PR DESCRIPTION
## WLAND Token

**Type**: Pre-minted Fungible Token (Glyph FT v2)
**GlyphID**: `0dbd046d8c5ab8b7631cd896c271c65bf26cc578aa958a620543a4f0a6d7294b:0`
**Block**: 435790 (Mainnet)

### Token Info
- Ticker: WLAND
- Max Supply: 1,000,000,000 (fully pre-minted)
- Decimals: 8
- Description: WLAND Token on Radiant Blockchain for the WLAND VPN ecosystem.

### Discord Publication
⏳ Discord post in #tokens-listings will be linked here after publication.

---
*Note: WLAND is a pre-minted FT (not dMint). Mining-specific fields are marked N/A.*